### PR TITLE
Revisit the search activity tests to get to 100% coverage.

### DIFF
--- a/app/src/main/java/com/pajato/argus/SearchActivity.kt
+++ b/app/src/main/java/com/pajato/argus/SearchActivity.kt
@@ -28,12 +28,11 @@ class SearchActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Create the activity by establishing the layout, the toolbar and putting text watchers on
+        // the edit text boxes so that the save button can enabled/disabled appropriately.
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_search)
         setSupportActionBar(searchToolbar)
-
-        // Set up the search name and network properties to enable/disable the save button on text
-        // changes.
         searchName.afterTextChanged { processSaveButtonState() }
         network.afterTextChanged { processSaveButtonState() }
     }
@@ -58,19 +57,17 @@ class SearchActivity : AppCompatActivity() {
     }
 
     override fun onResume() {
+        // Add the auto-fill resources to the networks input and set the focus on the search name
+        // edit text widget (and cause the soft keyboard to display if there is no hard keyboard).
         super.onResume()
-        // Add the auto-fill resources to the networks input.
         val networks = resources.getStringArray(R.array.networks).toList()
-        val arrayAdapter = ArrayAdapter<String>(this, android.R.layout.simple_dropdown_item_1line, networks)
-        network.setAdapter(arrayAdapter)
-
-        // Force the activity to focus on the name input
+        val id = android.R.layout.simple_dropdown_item_1line
+        network.setAdapter(ArrayAdapter<String>(this, id, networks))
         searchName.requestFocus()
-        val imm: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.showSoftInput(searchName, InputMethodManager.SHOW_IMPLICIT)
     }
 
     private fun save() {
+        // Return the collected data to the main activity.
         val result = Intent()
         result.putExtra(TYPE_KEY, "video")
         result.putExtra(TITLE_KEY, searchName.editableText.toString())
@@ -80,12 +77,11 @@ class SearchActivity : AppCompatActivity() {
     }
 
     private fun EditText.afterTextChanged(afterTextChanged: (String) -> Unit) {
+        // Establish an edit text extension function to deal with the save button.
         this.addTextChangedListener(object : TextWatcher {
-            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-            }
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
 
-            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
-            }
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {}
 
             override fun afterTextChanged(editable: Editable?) {
                 afterTextChanged.invoke(editable.toString())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,12 +16,22 @@
     <string name="searchName">Title</string>
     <string name="networkName">Network</string>
     <string-array name="networks">
-        <item>Netflix</item>
-        <item>HBO</item>
-        <item>PBS</item>
         <item>ABC</item>
-        <item>Hulu</item>
-        <item>BritBox</item>
         <item>Amazon</item>
+        <item>BritBox</item>
+        <item>Cinemax</item>
+        <item>Fox</item>
+        <item>Google Play</item>
+        <item>HBO Go</item>
+        <item>HBO Now</item>
+        <item>Hulu</item>
+        <item>NBC</item>
+        <item>Netflix</item>
+        <item>PBS</item>
+        <item>Showtime</item>
+        <item>Starz</item>
+        <item>TBS</item>
+        <item>The CW</item>
+        <item>YouTube Red</item>
     </string-array>
 </resources>


### PR DESCRIPTION
<h1>Rationale</h1>

In this commit, the onResume() issue (whereby one line of code that is executed gets reported by Jacoco to have 2 missed branches and 5 missed instructions) is addressed.  The resolution is to eliminate the input method manager code entirely and let Android deal with it as a side effect of handling the focus.  This reasonable because there may be a hardware keyboard which makes this code moot.

Also, the list of network seeds is expanded and the code comments in SearchActivity.kt has been enhanced.

<h1>File changes:</h1>

modified:   app/src/main/java/com/pajato/argus/SearchActivity.kt

- Summary: fix onResume() to reach 100% coverage and enhance the code comments.

modified:   app/src/main/res/values/strings.xml

- Summary: enhance the network list.