### PR TITLE
Initialize Adapter for RecyclerView

### DIFF
--- a/app/src/androidTest/java/com/pajato/argus/ListAdapterTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/ListAdapterTest.kt
@@ -6,6 +6,7 @@ import android.support.test.espresso.action.ViewActions.replaceText
 import android.support.test.espresso.matcher.ViewMatchers
 import android.support.test.espresso.matcher.ViewMatchers.*
 import android.support.v7.widget.RecyclerView
+import kotlinx.android.synthetic.main.non_empty_list_content_main.*
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -14,7 +15,7 @@ class ListAdapterTest : ActivityTestBase<MainActivity>(MainActivity::class.java)
     @Test
     fun testInitialState() {
         // Assert that the adapter is empty on start.
-        val list: RecyclerView = rule.activity.findViewById(R.id.listItems)
+        val list: RecyclerView = rule.activity.listItems
         val adapter: ListAdapter = list.adapter as ListAdapter
         val message = "The adapter does not have the correct number of elements!"
         assertEquals(message, 0, adapter.itemCount)
@@ -23,7 +24,7 @@ class ListAdapterTest : ActivityTestBase<MainActivity>(MainActivity::class.java)
     @Test
     fun testEmptyListToFullList() {
         // Setup the Data to enter into the adapter.
-        val list: RecyclerView = rule.activity.findViewById(R.id.listItems)
+        val list: RecyclerView = rule.activity.listItems
         val adapter: ListAdapter = list.adapter as ListAdapter
         val videoName = "Luther"
         val network = "HBO Now"

--- a/app/src/androidTest/java/com/pajato/argus/ListAdapterTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/ListAdapterTest.kt
@@ -1,0 +1,49 @@
+package com.pajato.argus
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.action.ViewActions.replaceText
+import android.support.test.espresso.matcher.ViewMatchers
+import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.v7.widget.RecyclerView
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+class ListAdapterTest : ActivityTestBase<MainActivity>(MainActivity::class.java) {
+    @Test
+    fun testInitialState() {
+        // Assert that the adapter is empty on start.
+        val list: RecyclerView = rule.activity.findViewById(R.id.listItems)
+        val adapter: ListAdapter = list.adapter as ListAdapter
+        val message = "The adapter does not have the correct number of elements!"
+        assertEquals(message, 0, adapter.itemCount)
+    }
+
+    @Test
+    fun testEmptyListToFullList() {
+        // Setup the Data to enter into the adapter.
+        val list: RecyclerView = rule.activity.findViewById(R.id.listItems)
+        val adapter: ListAdapter = list.adapter as ListAdapter
+        val videoName = "Luther"
+        val network = "HBO Now"
+        val type = "video"
+        onView(withId(R.id.fab)).perform(click())
+
+        // Utilize espresso to wait for the activity to appear, then enter our data
+        checkViewVisibility(withId(R.id.save_button), ViewMatchers.Visibility.VISIBLE)
+        onView(withId(R.id.searchName)).perform(replaceText(videoName))
+        onView(withId(R.id.network)).perform(replaceText(network))
+        onView(withId(R.id.save_button)).perform(click())
+
+        // Test that the ActivityResult has interacted with the MainActivity & the data is displayed
+        checkViewVisibility(withId(R.id.emptyListFrame), ViewMatchers.Visibility.GONE)
+        checkViewVisibility(ViewMatchers.withId(R.id.listItems), ViewMatchers.Visibility.VISIBLE)
+        assertEquals(adapter.itemCount, 1)
+        val video = adapter.items[0]
+        assertEquals(video.title, videoName)
+        assertEquals(video.network, network)
+        assertEquals(video.type, type)
+    }
+
+}

--- a/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
@@ -17,6 +17,12 @@
 
 package com.pajato.argus
 
+import android.app.Activity
+import android.app.Instrumentation
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.intent.Intents.intending
+import android.support.test.espresso.intent.matcher.IntentMatchers.toPackage
 import android.support.test.espresso.matcher.ViewMatchers.Visibility.INVISIBLE
 import android.support.test.espresso.matcher.ViewMatchers.Visibility.VISIBLE
 import android.support.test.espresso.matcher.ViewMatchers.withId
@@ -34,5 +40,28 @@ class MainActivityTest : ActivityTestBase<MainActivity>(MainActivity::class.java
         checkViewVisibility(withId(R.id.nav_view), INVISIBLE)
         checkViewVisibility(withId(R.id.toolbar), VISIBLE)
         checkViewVisibility(withId(R.id.fab), VISIBLE)
+    }
+
+    @Test fun testActivityResultNullData() {
+        val result = Instrumentation.ActivityResult(Activity.RESULT_OK, null)
+        intending(toPackage("com.pajato.argus")).respondWith(result)
+
+        onView(withId(R.id.fab)).perform(click())
+
+        checkViewVisibility(withId(R.id.emptyListIcon), VISIBLE)
+    }
+
+    @Test fun testActivityResultSearch() {
+        val result = Instrumentation.ActivityResult(Activity.RESULT_OK, null)
+        intending(toPackage("com.pajato.argus")).respondWith(result)
+        onView(withId(R.id.fab)).perform(click())
+        checkViewVisibility(withId(R.id.emptyListIcon), VISIBLE)
+    }
+
+    @Test fun testActivityResultCanceled() {
+        val result = Instrumentation.ActivityResult(Activity.RESULT_CANCELED, null)
+        intending(toPackage("com.pajato.argus")).respondWith(result)
+        onView(withId(R.id.fab)).perform(click())
+        checkViewVisibility(withId(R.id.emptyListIcon), VISIBLE)
     }
 }

--- a/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/MainActivityTest.kt
@@ -45,15 +45,6 @@ class MainActivityTest : ActivityTestBase<MainActivity>(MainActivity::class.java
     @Test fun testActivityResultNullData() {
         val result = Instrumentation.ActivityResult(Activity.RESULT_OK, null)
         intending(toPackage("com.pajato.argus")).respondWith(result)
-
-        onView(withId(R.id.fab)).perform(click())
-
-        checkViewVisibility(withId(R.id.emptyListIcon), VISIBLE)
-    }
-
-    @Test fun testActivityResultSearch() {
-        val result = Instrumentation.ActivityResult(Activity.RESULT_OK, null)
-        intending(toPackage("com.pajato.argus")).respondWith(result)
         onView(withId(R.id.fab)).perform(click())
         checkViewVisibility(withId(R.id.emptyListIcon), VISIBLE)
     }

--- a/app/src/androidTest/java/com/pajato/argus/SearchActivityTest.kt
+++ b/app/src/androidTest/java/com/pajato/argus/SearchActivityTest.kt
@@ -45,13 +45,23 @@ class SearchActivityTest : ActivityTestBase<SearchActivity>(SearchActivity::clas
         // The options menu item should be visible but disabled by default.
         checkViewVisibility(withId(R.id.save_button), VISIBLE)
         onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
+    }
 
+    @Test fun testSaveEnabling() {
         // Edit a value into the name edit text box and ensure the save button is still not enabled.
         val text = "Some video text"
         onView(withId(R.id.searchName)).perform(replaceText(text))
         onView(withText(text)).check(matches(isDisplayed()))
         onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
+        onView(withId(R.id.searchName)).perform(replaceText(text))
+        onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
 
+        val network = "HBO Go"
+        onView(withId(R.id.network)).perform(replaceText(network))
+        onView(withId(R.id.save_button)).check(matches(isEnabled()))
+    }
+
+    @Test fun testNetworkAutoComplete() {
         // Select the HBO network, ensure that the save button is now enabled and click on it.
         val hint = "h"
         val network = "HBO Go"
@@ -60,8 +70,7 @@ class SearchActivityTest : ActivityTestBase<SearchActivity>(SearchActivity::clas
                 .perform(click())
                 .perform(replaceText(hint))
         onData(equalTo(network)).inRoot(RootMatchers.isPlatformPopup()).perform(click())
-        onView(withId(R.id.save_button)).check(matches(not(isEnabled())))
-        onView(withId(R.id.searchName)).perform(replaceText(text))
-        onView(withId(R.id.save_button)).check(matches(isEnabled())).perform(click())
+        onView(withId(R.id.network)).check(matches(withText(network)))
     }
+
 }

--- a/app/src/main/java/com/pajato/argus/ListAdapter.kt
+++ b/app/src/main/java/com/pajato/argus/ListAdapter.kt
@@ -1,0 +1,31 @@
+package com.pajato.argus
+
+import android.support.v7.widget.LinearLayoutCompat
+import android.support.v7.widget.RecyclerView
+import android.view.ViewGroup
+import android.widget.TextView
+
+class ListAdapter(val items: MutableList<Video>) : RecyclerView.Adapter<ListAdapter.ViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(parent.inflate(R.layout.video_layout))
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val titleTextView: TextView = holder.layout.getChildAt(0) as TextView
+        titleTextView.text = items[position].title
+        val networkTextView: TextView = holder.layout.getChildAt(1) as TextView
+        networkTextView.text = items[position].network
+    }
+
+    override fun getItemCount(): Int {
+        return items.size
+    }
+
+    fun addItem(video : Video) {
+        items.add(video)
+        this.notifyItemInserted(items.size - 1)
+    }
+
+    class ViewHolder(val layout: LinearLayoutCompat) : RecyclerView.ViewHolder(layout)
+}

--- a/app/src/main/java/com/pajato/argus/ListAdapter.kt
+++ b/app/src/main/java/com/pajato/argus/ListAdapter.kt
@@ -1,20 +1,22 @@
 package com.pajato.argus
 
-import android.support.v7.widget.LinearLayoutCompat
 import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 
 class ListAdapter(val items: MutableList<Video>) : RecyclerView.Adapter<ListAdapter.ViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        return ViewHolder(parent.inflate(R.layout.video_layout))
+        val layout = LayoutInflater.from(parent.context).inflate(R.layout.video_layout, parent, false)
+        return ViewHolder(layout)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val titleTextView: TextView = holder.layout.getChildAt(0) as TextView
+        val titleTextView: TextView = holder.layout.findViewWithTag("title")
         titleTextView.text = items[position].title
-        val networkTextView: TextView = holder.layout.getChildAt(1) as TextView
+        val networkTextView: TextView = holder.layout.findViewWithTag("network")
         networkTextView.text = items[position].network
     }
 
@@ -27,5 +29,5 @@ class ListAdapter(val items: MutableList<Video>) : RecyclerView.Adapter<ListAdap
         this.notifyItemInserted(items.size - 1)
     }
 
-    class ViewHolder(val layout: LinearLayoutCompat) : RecyclerView.ViewHolder(layout)
+    class ViewHolder(val layout: View) : RecyclerView.ViewHolder(layout)
 }

--- a/app/src/main/java/com/pajato/argus/MainActivity.kt
+++ b/app/src/main/java/com/pajato/argus/MainActivity.kt
@@ -28,18 +28,19 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
 
-        if (resultCode == Activity.RESULT_OK && requestCode == Companion.SEARCH_REQUEST && data != null) {
-            val type = data.extras.get(TYPE_KEY) as String
-            val title = data.extras.get(TITLE_KEY) as String
-            val provider = data.extras.get(NETWORK_KEY) as String
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            val type = data.getStringExtra(TYPE_KEY)
+            val title = data.getStringExtra(TITLE_KEY)
+            val provider = data.getStringExtra(NETWORK_KEY)
 
             val video = Video(title, provider, type)
 
             emptyListFrame.visibility = View.GONE
             nonEmptyListFrame.visibility = View.VISIBLE
 
-            val adapter: ListAdapter = (listItems.adapter as ListAdapter)
-            adapter.addItem(video)
+            val adapter = listItems.adapter
+            if (adapter is ListAdapter)
+                adapter.addItem(video)
         }
     }
 
@@ -63,7 +64,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
 
         val layoutManager: RecyclerView.LayoutManager = LinearLayoutManager(this)
         listItems.layoutManager = layoutManager
-        val adapter: RecyclerView.Adapter<ListAdapter.ViewHolder> = ListAdapter(mutableListOf())
+        val adapter = ListAdapter(mutableListOf())
         listItems.adapter = adapter
     }
 

--- a/app/src/main/java/com/pajato/argus/MainActivity.kt
+++ b/app/src/main/java/com/pajato/argus/MainActivity.kt
@@ -1,22 +1,47 @@
 package com.pajato.argus
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.support.design.widget.NavigationView
 import android.support.v4.view.GravityCompat
 import android.support.v7.app.ActionBarDrawerToggle
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
+import com.pajato.argus.SearchActivity.Companion.NETWORK_KEY
+import com.pajato.argus.SearchActivity.Companion.TITLE_KEY
+import com.pajato.argus.SearchActivity.Companion.TYPE_KEY
 import kotlinx.android.extensions.CacheImplementation
 import kotlinx.android.extensions.ContainerOptions
 import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.app_bar_main.*
+import kotlinx.android.synthetic.main.non_empty_list_content_main.*
 
 @ContainerOptions(CacheImplementation.NO_CACHE)
 class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelectedListener {
 
     // Public instance methods.
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        if (resultCode == Activity.RESULT_OK && requestCode == Companion.SEARCH_REQUEST && data != null) {
+            val type = data.extras.get(TYPE_KEY) as String
+            val title = data.extras.get(TITLE_KEY) as String
+            val provider = data.extras.get(NETWORK_KEY) as String
+
+            val video = Video(title, provider, type)
+
+            emptyListFrame.visibility = View.GONE
+            nonEmptyListFrame.visibility = View.VISIBLE
+
+            val adapter: ListAdapter = (listItems.adapter as ListAdapter)
+            adapter.addItem(video)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -35,6 +60,11 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         toggle.syncState()
 
         nav_view.setNavigationItemSelectedListener(this)
+
+        val layoutManager: RecyclerView.LayoutManager = LinearLayoutManager(this)
+        listItems.layoutManager = layoutManager
+        val adapter: RecyclerView.Adapter<ListAdapter.ViewHolder> = ListAdapter(mutableListOf())
+        listItems.adapter = adapter
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/pajato/argus/SearchActivity.kt
+++ b/app/src/main/java/com/pajato/argus/SearchActivity.kt
@@ -1,7 +1,6 @@
 package com.pajato.argus
 
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.graphics.PorterDuff
 import android.os.Bundle
@@ -11,7 +10,6 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.Menu
 import android.view.MenuItem
-import android.view.inputmethod.InputMethodManager
 import android.widget.ArrayAdapter
 import android.widget.EditText
 import kotlinx.android.extensions.CacheImplementation

--- a/app/src/main/java/com/pajato/argus/StringExtensions.kt
+++ b/app/src/main/java/com/pajato/argus/StringExtensions.kt
@@ -1,9 +1,5 @@
 package com.pajato.argus
 
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-
 /** Return a new String where  white-space sequences are replaced with a single space. */
 fun String.stripMiddle() = this.replace(Regex("\\s+"), " ")
 
@@ -15,10 +11,5 @@ fun String.stripRight() = this.replace(Regex("\\s+$"), "")
 
 /** Return a String where all white-space has been trimmed. */
 fun String.strip() = this.stripLeft().stripRight().stripMiddle()
-
-fun  <T : View> ViewGroup.inflate(resId: Int): T {
-    @Suppress("UNCHECKED_CAST")
-    return LayoutInflater.from(context).inflate(resId, this, false) as T
-}
 
 class Video(val title: String, val network: String, val type: String = "")

--- a/app/src/main/java/com/pajato/argus/StringExtensions.kt
+++ b/app/src/main/java/com/pajato/argus/StringExtensions.kt
@@ -1,5 +1,9 @@
 package com.pajato.argus
 
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
 /** Return a new String where  white-space sequences are replaced with a single space. */
 fun String.stripMiddle() = this.replace(Regex("\\s+"), " ")
 
@@ -11,3 +15,10 @@ fun String.stripRight() = this.replace(Regex("\\s+$"), "")
 
 /** Return a String where all white-space has been trimmed. */
 fun String.strip() = this.stripLeft().stripRight().stripMiddle()
+
+fun  <T : View> ViewGroup.inflate(resId: Int): T {
+    @Suppress("UNCHECKED_CAST")
+    return LayoutInflater.from(context).inflate(resId, this, false) as T
+}
+
+class Video(val title: String, val network: String, val type: String = "")

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -20,17 +20,23 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <FrameLayout android:id="@+id/emptyListFrame"
+    <FrameLayout
+        android:id="@+id/emptyListFrame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="visible">
+        android:visibility="visible"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
         <include layout="@layout/empty_list_content_main" />
     </FrameLayout>
 
-    <FrameLayout android:id="@+id/nonEmptyListFrame"
+    <FrameLayout
+        android:id="@+id/nonEmptyListFrame"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="gone">
+        android:visibility="gone"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
         <include layout="@layout/non_empty_list_content_main" />
     </FrameLayout>
 
@@ -41,6 +47,6 @@
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
         android:tint="@color/colorIcons"
-        app:srcCompat="@drawable/ic_note_black_24dp"/>
+        app:srcCompat="@drawable/ic_note_black_24dp" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/non_empty_list_content_main.xml
+++ b/app/src/main/res/layout/non_empty_list_content_main.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -9,9 +8,10 @@
     tools:context="com.pajato.argus.MainActivity"
     tools:showIn="@layout/app_bar_main">
 
-    <android.support.v7.widget.RecyclerView android:id="@+id/listItems"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/listItems"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_marginBottom="8dp"
         android:layout_marginLeft="8dp"
         android:layout_marginRight="8dp"

--- a/app/src/main/res/layout/video_layout.xml
+++ b/app/src/main/res/layout/video_layout.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:tag="List Entry">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:tag="@string/searchName"
+        android:textSize="20sp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:tag="@string/networkName"
+        android:textSize="20sp" />
+
+</android.support.v7.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/video_layout.xml
+++ b/app/src/main/res/layout/video_layout.xml
@@ -10,13 +10,13 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
-        android:tag="@string/searchName"
+        android:tag="title"
         android:textSize="20sp" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:tag="@string/networkName"
+        android:tag="network"
         android:textSize="20sp" />
 
 </android.support.v7.widget.LinearLayoutCompat>


### PR DESCRIPTION
# Rationale
Moving forward with development, the RecyclerView now has a functional adapter that allows for the additions of new videos, which are currently displayed by a Pair of TextViews within the RecyclerView. Video data is added to the Activity Result of **SearchActivity** and is stored in the Adapter. Multiple items can be added, but cannot be manipulated in any way yet, nor is data persisted in any way once the Activity is destroyed.

# Changed Files

## MainActivity
* Accepts data from **SearchActivity** in *onActivityResult* by adding an item to the adapter's data.
* Initializes the **ListAdapter** for the RecyclerView in *onCreate*

## SearchActivity
* Removed unnecessary imports.

## StringExtensions
* Added extension method ViewGroup.inflate that allows for a quicker way to inflate a layout for our RecyclerView.
* Added POJO (POKO?) class Video to store the data for each entry in the RecyclerView

## app_bar_main
* Auto-formatted code to meet Android Standards
* Fixed a bug where the RecyclerView would render behind the Toolbar

## non_empty_list_content_main
* Fixed the size of the RecyclerView so that it would properly display.

## SearchActivityTest
* Split the test methods to be a bit more readable and to be split in more logical pieces.

# New Files

## ListAdapter
* The adapter class for the *listItems* **RecyclerView**, which is relatively simple. Its data is stored as the POJO class **Video** which has 3 fields as originally specified in **SearchActivity**'s intent result.

## video_layout
* A new layout for the entries in the *listItems* **RecyclerView**. It is a simple LinearLayout with two TextViews that store the video's name and the network provider.

## ListAdapterTest
* Tests the new adapter for the RecyclerView that ensures that it starts empty, and traverse through the **SearchActivity**, then ensure that the adapter has updated once we return to the **MainActivity**.