### PR TITLE
More Exact Input Control

### DIFF
--- a/app/src/androidTest/java/com/pajato/argus/ActivityTestBase.kt
+++ b/app/src/androidTest/java/com/pajato/argus/ActivityTestBase.kt
@@ -79,4 +79,8 @@ import org.junit.runner.RunWith
     fun Activity.runOnUiThread(f: () -> Unit) {
         runOnUiThread { f() }
     }
+
+    fun Activity.getIDName(id: Int): String {
+        return this.resources.getResourceEntryName(id)
+    }
 }

--- a/app/src/main/java/com/pajato/argus/ListAdapter.kt
+++ b/app/src/main/java/com/pajato/argus/ListAdapter.kt
@@ -21,14 +21,12 @@ class ListAdapter(val items: MutableList<Video>) : RecyclerView.Adapter<ListAdap
         val titleTextView = holder.layout.titleText
         titleTextView.setText(items[position].title)
         val titleManager = EditorHelper(titleTextView, holder.layout)
-        titleTextView.setOnEditorActionListener(titleManager)
         titleTextView.addTextChangedListener(titleManager)
 
         // Do the same for the network view.
         val networkTextView = holder.layout.networkText
         networkTextView.setText(items[position].network)
         val networkManager = EditorHelper(networkTextView, holder.layout)
-        networkTextView.setOnEditorActionListener(networkManager)
         networkTextView.addTextChangedListener(networkManager)
 
         val networks = holder.layout.context.resources.getStringArray(R.array.networks).toList()
@@ -39,6 +37,7 @@ class ListAdapter(val items: MutableList<Video>) : RecyclerView.Adapter<ListAdap
         val deleteButton = holder.layout.deleteButton
         deleteButton.setOnClickListener(Delete(holder, this))
         deleteButton.setColorFilter(Color.GRAY, PorterDuff.Mode.SRC_ATOP)
+        holder.layout.card_view.setOnTouchListener(TakeFocus())
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/com/pajato/argus/MainActivity.kt
+++ b/app/src/main/java/com/pajato/argus/MainActivity.kt
@@ -68,6 +68,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
         listItems.layoutManager = layoutManager
         val adapter = ListAdapter(mutableListOf())
         listItems.adapter = adapter
+        listItems.setOnTouchListener(TakeFocus(this))
 
         // Query the Database and update the adapter.
         val items: MutableList<Video> = getVideosFromDb(applicationContext)

--- a/app/src/main/res/layout/app_bar_main.xml
+++ b/app/src/main/res/layout/app_bar_main.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:focusableInTouchMode="true"
     tools:context="com.pajato.argus.MainActivity">
 
     <android.support.design.widget.AppBarLayout

--- a/app/src/main/res/layout/video_layout.xml
+++ b/app/src/main/res/layout/video_layout.xml
@@ -13,6 +13,9 @@
     android:layout_marginRight="1dp"
     android:layout_marginStart="1dp"
     android:layout_marginTop="1dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     card_view:cardCornerRadius="8dp">
 
     <android.support.constraint.ConstraintLayout
@@ -21,21 +24,25 @@
 
         <EditText
             android:id="@+id/titleText"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="8dp"
             android:layout_marginStart="8dp"
             android:background="@android:color/transparent"
             android:imeOptions="actionNext"
-            android:inputType="text"
+            android:inputType="textCapWords"
+            android:paddingEnd="64dp"
+            android:paddingLeft="0dp"
+            android:paddingRight="64dp"
+            android:paddingStart="0dp"
             android:textSize="24sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <AutoCompleteTextView
             android:id="@+id/networkText"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="16dp"
@@ -48,6 +55,10 @@
             android:imeOptions="actionDone"
             android:inputType="text|textFilter"
             android:paddingBottom="4dp"
+            android:paddingEnd="48dp"
+            android:paddingLeft="0dp"
+            android:paddingRight="48dp"
+            android:paddingStart="0dp"
             android:textSize="18sp"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toBottomOf="@id/titleText" />


### PR DESCRIPTION
# Rationale
The new feature of editing content is great, but interfacing with it and attempting to cease interfacing with it proved difficult and resulted in putting up with the soft keyboard being open a vast majority of the time, or would lead to inadvertently exiting the app with the back button. Now, we are able to dismiss the keyboard by tapping on the Card View for each of the video entries or by tapping on the background of the main layout, which is filled by the RecyclerView. It will allow for more intuitive dismissals of the soft keyboard and a less frustrating editing experience. In addition, it is less prone to accidentally clicking on a text view and summoning the software keyboard when one is attempting to scroll.

# Changed Files

## InputEventListeners
* New class **TakeFocus** which controls the focus for the MainActivity, used primarily to both hide the soft keyboard and remove the input cursor when the user taps on another, non-editable view.
* Removed the OnEditorActionListener implementation, as it essentially enumerated a buggier version of the built in editor action listener.

## ListAdapter
* Removed setting an **OnEditorActionListener** from the titleText and networkText **EditText** views, as we no longer implement those.
* Added the new **OnTouchListener** to our CardView.

## MainActivity
* Added the new **OnTouchListener** to the RecyclerView.

## layout/app_bar_main
* Removed the *focusableInTouchMode* attribute from the base level **CoordinatorLayout** to help facilitate more exact behavior when dealing with dismissing the keyboard by clicking on alternate views.

## layout/video_layout
* Added *clickable*, *focusable*, and *focusableInTouchMode* attributes to the base **CardView** to help facilitate more exact behavior when dealing with dismissing the keyboard by clicking on alternate views.
* The width of the titleText and networkText **EditText**s now wraps to their contents, such that they are no longer taking up the entire width of the screen. This allows for easier dismissal of the soft keyboard. Also added a bit of padding to these texts so that they are easier to click on when the text within them is short.

## ActivityTestBase
* Added extension function Activity.getIDName to allow for a bit more shorthand access to the getResourceEntryName method. This allows for shorter but more thorough assert messages.

## MainActivityTest
* Added a new test that ensures that the focus and input methods respond properly when a user clicks on EditTexts or other views in the Main Activity layout when it is populated with data.